### PR TITLE
 Ensuring a proper sync between flux and table views.

### DIFF
--- a/src/lerfob/carbonbalancetool/productionlines/AbstractExtractionProcessor.java
+++ b/src/lerfob/carbonbalancetool/productionlines/AbstractExtractionProcessor.java
@@ -24,12 +24,14 @@ import java.awt.Graphics;
 import java.util.Collection;
 import java.util.List;
 
+import lerfob.carbonbalancetool.productionlines.AbstractProductionLineProcessor.MemberLabel;
 import lerfob.carbonbalancetool.productionlines.ProductionProcessorManager.CarbonTestProcessUnit;
 import repicea.gui.permissions.REpiceaGUIPermission;
 import repicea.simulation.processsystem.ProcessUnit;
 import repicea.simulation.processsystem.Processor;
 import repicea.simulation.processsystem.ProcessorButton;
 import repicea.simulation.processsystem.SystemPanel;
+import repicea.simulation.processsystem.ProcessorListTable.MemberInformation;
 
 /**
  * The AbstractExtractionProcessor class defines a process that extracts something before splitting
@@ -128,5 +130,23 @@ public abstract class AbstractExtractionProcessor extends AbstractProcessor {
 		return guiInterface;
 	}
 
-	
+	@Override
+	public List<MemberInformation> getInformationsOnMembers() {
+		List<MemberInformation> cellValues = super.getInformationsOnMembers();
+		cellValues.add(new MemberInformation(AbstractProductionLineProcessor.MemberLabel.FunctionUnitBiomass, double.class, functionUnitBiomass));
+		cellValues.add(new MemberInformation(AbstractProductionLineProcessor.MemberLabel.EmissionFunctionUnit, double.class, emissionsByFunctionalUnit));
+		return cellValues;
+	}
+
+	@Override
+	public void processChangeToMember(Enum label, Object value) {
+		if (label == AbstractProductionLineProcessor.MemberLabel.FunctionUnitBiomass) {
+			functionUnitBiomass = (double) value;
+		} else if (label == AbstractProductionLineProcessor.MemberLabel.EmissionFunctionUnit) {
+			emissionsByFunctionalUnit = (double) value;
+		} else {
+			super.processChangeToMember(label, value);
+		}
+	}
+
 }

--- a/src/lerfob/carbonbalancetool/productionlines/AbstractProcessor.java
+++ b/src/lerfob/carbonbalancetool/productionlines/AbstractProcessor.java
@@ -122,4 +122,7 @@ public abstract class AbstractProcessor extends Processor {
 		return super.getProcessFeaturesPanel();
 	}
 
+	
+
+	
 }

--- a/src/lerfob/carbonbalancetool/productionlines/CarbonUnitFeature.java
+++ b/src/lerfob/carbonbalancetool/productionlines/CarbonUnitFeature.java
@@ -27,6 +27,7 @@ import repicea.gui.REpiceaUIObject;
 import repicea.serial.SerializerChangeMonitor;
 import repicea.simulation.processsystem.ProcessorListTable.MemberHandler;
 import repicea.simulation.processsystem.ProcessorListTable.MemberInformation;
+import repicea.simulation.processsystem.ResourceReleasable;
 
 /**
  * The CarbonUnitFeature class defines some characteristics of carbon units contained in a wood piece. <p>
@@ -34,7 +35,7 @@ import repicea.simulation.processsystem.ProcessorListTable.MemberInformation;
  * @author Mathieu Fortin - 2012
  */
 @SuppressWarnings("serial")
-public class CarbonUnitFeature implements Serializable, REpiceaUIObject, MemberHandler {
+public class CarbonUnitFeature implements Serializable, REpiceaUIObject, MemberHandler, ResourceReleasable {
 
 	static {
 		SerializerChangeMonitor.registerClassNameChange("lerfob.carbonbalancetool.productionlines.CarbonUnitFeature$LifetimeMode",
@@ -125,8 +126,17 @@ public class CarbonUnitFeature implements Serializable, REpiceaUIObject, MemberH
 	}
 
 	@Override
-	public void processChangeToMember(String fieldName, Object value) {
-		getDecayFunction().processChangeToMember(fieldName, value);
+	public void processChangeToMember(Enum<?> label, Object value) {
+		getDecayFunction().processChangeToMember(label, value);
+	}
+
+	@Override
+	public void releaseResources() {
+		if (userInterfacePanel != null) {
+			userInterfacePanel.doNotListenToAnymore();
+			userInterfacePanel = null;
+		}
+		getDecayFunction().releaseResources();
 	}
 
 

--- a/src/lerfob/carbonbalancetool/productionlines/DecayFunction.java
+++ b/src/lerfob/carbonbalancetool/productionlines/DecayFunction.java
@@ -33,6 +33,7 @@ import repicea.gui.components.NumberFormatFieldFactory.NumberFieldListener;
 import repicea.math.utility.GammaUtility;
 import repicea.simulation.processsystem.ProcessorListTable.MemberHandler;
 import repicea.simulation.processsystem.ProcessorListTable.MemberInformation;
+import repicea.simulation.processsystem.ResourceReleasable;
 import repicea.util.REpiceaTranslator;
 import repicea.util.REpiceaTranslator.TextableEnum;
 
@@ -42,7 +43,7 @@ import repicea.util.REpiceaTranslator.TextableEnum;
  * @author Mathieu Fortin - October 2010
  */
 @SuppressWarnings("serial")
-class DecayFunction implements Serializable, REpiceaUIObject, NumberFieldListener, ItemListener, MemberHandler {
+class DecayFunction implements Serializable, REpiceaUIObject, NumberFieldListener, ItemListener, MemberHandler, ResourceReleasable {
 
 	protected static enum MemberLabel implements TextableEnum {
 		DecayFunctionType("Decay function type", "Type de d\u00E9croissance"),
@@ -247,20 +248,28 @@ class DecayFunction implements Serializable, REpiceaUIObject, NumberFieldListene
 	@Override
 	public List<MemberInformation> getInformationsOnMembers() {
 		List<MemberInformation> memberInfo = new ArrayList<MemberInformation>();	
-		memberInfo.add(new MemberInformation(MemberLabel.DecayFunctionType.toString(), DecayFunctionType.class, functionType));
-		memberInfo.add(new MemberInformation(MemberLabel.LifetimeMode.toString(), LifetimeMode.class, lifetimeMode));
-		memberInfo.add(new MemberInformation(MemberLabel.Lifetime.toString(), double.class, getLifetime()));
+		memberInfo.add(new MemberInformation(MemberLabel.DecayFunctionType, DecayFunctionType.class, functionType));
+		memberInfo.add(new MemberInformation(MemberLabel.LifetimeMode, LifetimeMode.class, lifetimeMode));
+		memberInfo.add(new MemberInformation(MemberLabel.Lifetime, double.class, getLifetime()));
 		return memberInfo;
 	}
 
 	@Override
-	public void processChangeToMember(String fieldName, Object value) {
-		if (fieldName.equals(MemberLabel.DecayFunctionType.toString())) {
+	public void processChangeToMember(Enum<?> label, Object value) {
+		if (label == MemberLabel.DecayFunctionType) {
 			functionType = (DecayFunctionType) value;
-		} else if (fieldName.equals(MemberLabel.LifetimeMode.toString())) {
+		} else if (label == MemberLabel.LifetimeMode) {
 			lifetimeMode = (LifetimeMode) value;
-		} else if (fieldName.equals(MemberLabel.Lifetime.toString())) {
+		} else if (label == MemberLabel.Lifetime) {
 			setLifetime((double) value);
 		} 
+	}
+
+	@Override
+	public void releaseResources() {
+		if (userInterface != null) {
+			userInterface.doNotListenToAnymore();
+			userInterface = null;
+		}
 	}
 }

--- a/src/lerfob/carbonbalancetool/productionlines/EndUseWoodProductCarbonUnitFeature.java
+++ b/src/lerfob/carbonbalancetool/productionlines/EndUseWoodProductCarbonUnitFeature.java
@@ -306,25 +306,25 @@ public class EndUseWoodProductCarbonUnitFeature extends CarbonUnitFeature implem
 	@Override
 	public List<MemberInformation> getInformationsOnMembers() {
 		List<MemberInformation> memberInfo = super.getInformationsOnMembers();
-		memberInfo.add(new MemberInformation(AbstractProductionLineProcessor.MemberLabel.FunctionUnitBiomass.toString(), double.class, getBiomassOfFunctionalUnitMg()));
-		memberInfo.add(new MemberInformation(AbstractProductionLineProcessor.MemberLabel.EmissionFunctionUnit.toString(), double.class, getEmissionsMgCO2EqByFunctionalUnit()));
-		memberInfo.add(new MemberInformation(MemberLabel.UseClass.toString(), UseClass.class, getUseClass()));
-		memberInfo.add(new MemberInformation(MemberLabel.Substitution.toString(), double.class, relativeSubstitutionCO2EqFonctionalUnit));
+		memberInfo.add(new MemberInformation(AbstractProductionLineProcessor.MemberLabel.FunctionUnitBiomass, double.class, getBiomassOfFunctionalUnitMg()));
+		memberInfo.add(new MemberInformation(AbstractProductionLineProcessor.MemberLabel.EmissionFunctionUnit, double.class, getEmissionsMgCO2EqByFunctionalUnit()));
+		memberInfo.add(new MemberInformation(MemberLabel.UseClass, UseClass.class, getUseClass()));
+		memberInfo.add(new MemberInformation(MemberLabel.Substitution, double.class, relativeSubstitutionCO2EqFonctionalUnit));
 		return memberInfo;
 	}
 
 	@Override
-	public void processChangeToMember(String fieldName, Object value) {
-		if (fieldName.equals(AbstractProductionLineProcessor.MemberLabel.FunctionUnitBiomass.toString())) {
+	public void processChangeToMember(Enum<?> label, Object value) {
+		if (label == AbstractProductionLineProcessor.MemberLabel.FunctionUnitBiomass) {
 			biomassOfFunctionalUnit = (double) value;
-		} else if (fieldName.equals(AbstractProductionLineProcessor.MemberLabel.EmissionFunctionUnit.toString())) {
+		} else if (label == AbstractProductionLineProcessor.MemberLabel.EmissionFunctionUnit) {
 			emissionsByFunctionalUnit = (double) value;
-		} else if (fieldName.equals(MemberLabel.UseClass.toString())) {
+		} else if (label == MemberLabel.UseClass) {
 			setUseClass((UseClass) value);
-		} else if (fieldName.equals(MemberLabel.Substitution.toString())) {
+		} else if (label == MemberLabel.Substitution) {
 			relativeSubstitutionCO2EqFonctionalUnit = (double) value;
 		} else {
-			super.processChangeToMember(fieldName, value);
+			super.processChangeToMember(label, value);
 		}
 	}
 

--- a/src/lerfob/carbonbalancetool/productionlines/EnhancedProcessorInternalDialog.java
+++ b/src/lerfob/carbonbalancetool/productionlines/EnhancedProcessorInternalDialog.java
@@ -105,10 +105,10 @@ public class EnhancedProcessorInternalDialog extends ProcessorInternalDialog imp
 		setTopComponent();
 		REpiceaPanel featurePanel = getCaller().getProcessFeaturesPanel();
 		if (featurePanel != null) {
-			if (getCaller() instanceof AbstractProductionLineProcessor && getCaller().hasSubProcessors() ) {
-				setBottomComponent(new JPanel());
-			} else {
+			if (mustDisplayCarbonUnitFeatures(getCaller())) {
 				setBottomComponent(featurePanel);
+			} else {
+				setBottomComponent(new JPanel());
 			}
 		}
 		pack();
@@ -124,12 +124,10 @@ public class EnhancedProcessorInternalDialog extends ProcessorInternalDialog imp
 	@Override
 	protected JPanel setTopComponent() {
 		JPanel topComponent = super.setTopComponent();
-		if (getCaller().hasSubProcessors() || !(getCaller() instanceof ProductionLineProcessor)) { // this condition is because production line processors handle their emission within their carbon features
-//		if (getCaller().hasSubProcessors()) {
+		if (usesEmissionsAndFunctionalUnitFromAbstractProcessorClass(getCaller())) {
 			JPanel panel = UIControlManager.createSimpleHorizontalPanel(MessageID.FunctionalUnitBiomassLabel, functionUnitBiomass, 5, true);
 			topComponent.add(panel);
 			topComponent.add(Box.createVerticalStrut(5));
-
 			panel = UIControlManager.createSimpleHorizontalPanel(MessageID.EmissionsLabel, emissionsByFunctionUnit, 5, true);
 			topComponent.add(panel);
 			topComponent.add(Box.createVerticalStrut(5));
@@ -139,6 +137,17 @@ public class EnhancedProcessorInternalDialog extends ProcessorInternalDialog imp
 		return topComponent;
 	}
 
+	
+	static boolean usesEmissionsAndFunctionalUnitFromAbstractProcessorClass(AbstractProcessor p) {
+		return p instanceof AbstractExtractionProcessor ||
+				p instanceof LandfillProcessor || 
+				(p instanceof ProductionLineProcessor && p.hasSubProcessors());
+	}
+	
+	static boolean mustDisplayCarbonUnitFeatures(AbstractProcessor p) {
+		return !(p instanceof AbstractProductionLineProcessor) || !p.hasSubProcessors() ;
+	}
+	
 
 	@Override
 	public void listenTo() {

--- a/src/lerfob/carbonbalancetool/productionlines/LandfillCarbonUnitFeature.java
+++ b/src/lerfob/carbonbalancetool/productionlines/LandfillCarbonUnitFeature.java
@@ -163,19 +163,19 @@ public class LandfillCarbonUnitFeature extends CarbonUnitFeature implements Chan
 	@Override
 	public List<MemberInformation> getInformationsOnMembers() {
 		List<MemberInformation> memberInfo = super.getInformationsOnMembers();
-		memberInfo.add(new MemberInformation(MemberLabel.LandfillType.toString(), LandfillType.class, getLandfillType()));
-		memberInfo.add(new MemberInformation(MemberLabel.DocFraction.toString(), double.class, getDegradableOrganicCarbonFraction()));
+		memberInfo.add(new MemberInformation(MemberLabel.LandfillType, LandfillType.class, getLandfillType()));
+		memberInfo.add(new MemberInformation(MemberLabel.DocFraction, double.class, getDegradableOrganicCarbonFraction()));
 		return memberInfo;
 	}
 
 	@Override
-	public void processChangeToMember(String fieldName, Object value) {
-		if (fieldName.equals(MemberLabel.LandfillType.toString())) {
+	public void processChangeToMember(Enum<?> label, Object value) {
+		if (label == MemberLabel.LandfillType) {
 			landfillType = (LandfillType) value;
-		} else if (fieldName.equals(MemberLabel.DocFraction.toString())) {
+		} else if (label == MemberLabel.DocFraction) {
 			this.setDegradableOrganicCarbonFraction((double) value);
 		} else {
-			super.processChangeToMember(fieldName, value);
+			super.processChangeToMember(label, value);
 		}
 	}
 

--- a/src/lerfob/carbonbalancetool/productionlines/ProductionProcessorManagerDialog.java
+++ b/src/lerfob/carbonbalancetool/productionlines/ProductionProcessorManagerDialog.java
@@ -140,7 +140,7 @@ public class ProductionProcessorManagerDialog extends SystemManagerDialog implem
 		protected List<Processor> getProcessorList() {
 			List<Processor> processors = new ArrayList<Processor>();
 			for (Processor p : caller.getList()) {
-				if (p instanceof AbstractProductionLineProcessor) {
+				if (p instanceof AbstractProductionLineProcessor || p instanceof AbstractExtractionProcessor) {
 					processors.add(p);
 				}
 			}

--- a/src/repicea/simulation/processsystem/Processor.java
+++ b/src/repicea/simulation/processsystem/Processor.java
@@ -36,6 +36,8 @@ import repicea.gui.REpiceaUIObject;
 import repicea.gui.REpiceaUIObjectWithParent;
 import repicea.simulation.processsystem.ProcessorListTable.MemberHandler;
 import repicea.simulation.processsystem.ProcessorListTable.MemberInformation;
+import repicea.util.REpiceaTranslator;
+import repicea.util.REpiceaTranslator.TextableEnum;
 
 /**
  * A Processor instance represents a node in the flux configuration.<p>
@@ -45,9 +47,23 @@ import repicea.simulation.processsystem.ProcessorListTable.MemberInformation;
  * @see ProcessorButton
  */
 @SuppressWarnings("serial")
-public class Processor implements REpiceaUIObjectWithParent, REpiceaUIObject, CaretListener, Serializable, MemberHandler {
+public class Processor implements REpiceaUIObjectWithParent, REpiceaUIObject, CaretListener, Serializable, MemberHandler, ResourceReleasable {
 
-	protected static final String NameField = "Name";
+	protected static enum MemberLabel implements TextableEnum {
+		NameField("Name", "Nom");
+		
+		MemberLabel(String englishName, String frenchName) {
+			setText(englishName, frenchName);
+		}
+
+		@Override
+		public void setText(String englishText, String frenchText) {
+			REpiceaTranslator.setString(this, englishText, frenchText);
+		}
+		
+		@Override
+		public String toString() {return REpiceaTranslator.getString(this);}
+	}
 	
 	private Point originalLocation;
 	protected transient ProcessorButton guiInterface;
@@ -307,14 +323,21 @@ public class Processor implements REpiceaUIObjectWithParent, REpiceaUIObject, Ca
 	@Override
 	public List<MemberInformation> getInformationsOnMembers() {
 		List<MemberInformation> cellValues = new ArrayList<MemberInformation>();
-		cellValues.add(new MemberInformation(NameField, String.class, name));
+		cellValues.add(new MemberInformation(MemberLabel.NameField, String.class, name));
 		return cellValues;
 	}
 	
 	@Override
-	public void processChangeToMember(String fieldName, Object value) {
-		if (fieldName.equals(NameField)) {
+	public void processChangeToMember(Enum<?> label, Object value) {
+		if (label == MemberLabel.NameField) {
 			setName(value.toString());
+		}
+	}
+
+	@Override
+	public void releaseResources() {
+		if (guiInterface != null) {
+			guiInterface.releaseResources();
 		}
 	}
 

--- a/src/repicea/simulation/processsystem/ProcessorButton.java
+++ b/src/repicea/simulation/processsystem/ProcessorButton.java
@@ -46,7 +46,10 @@ import repicea.simulation.processsystem.UISetup.BasicMode;
  * creates a {@link ProcessorInternalDialog} instance, which contains the characteristics of the Processor.
  */
 @SuppressWarnings("serial")
-public class ProcessorButton extends SelectableJButton implements AnchorProvider, REpiceaShowableUIWithParent, REpiceaGUIPermissionProvider {
+public class ProcessorButton extends SelectableJButton implements AnchorProvider, 
+																	REpiceaShowableUIWithParent, 
+																	REpiceaGUIPermissionProvider,
+																	ResourceReleasable {
 
 	
 	protected static class DragGestureButtonMoveHandler extends DragGestureMoveComponentHandler<ProcessorButton> {
@@ -255,6 +258,13 @@ public class ProcessorButton extends SelectableJButton implements AnchorProvider
 		}
 	}
 
+	@Override
+	public void releaseResources() {
+		if (guiInterface != null) {
+			guiInterface.doNotListenToAnymore();
+			guiInterface = null;
+		}
+	}
 
 	@Override
 	protected Icon getDefaultIcon() {return UISetup.Icons.get(ProcessorButton.class.getName());}

--- a/src/repicea/simulation/processsystem/REpiceaOSVGFileHandlerUI.java
+++ b/src/repicea/simulation/processsystem/REpiceaOSVGFileHandlerUI.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of the repicea library.
+ * This file is part of the CAT library.
  *
  * Copyright (C) 2009-2021 Mathieu Fortin for Rouge-Epicea
  *

--- a/src/repicea/simulation/processsystem/ResourceReleasable.java
+++ b/src/repicea/simulation/processsystem/ResourceReleasable.java
@@ -1,0 +1,35 @@
+/*
+ * This file is part of the CAT library.
+ *
+ * Copyright (C) 2024 His Majesty the King in right of Canada
+ * Author: Mathieu Fortin, Canadian Forest Service 
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed with the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * Please see the license at http://www.gnu.org/copyleft/lesser.html.
+ */
+package repicea.simulation.processsystem;
+
+/**
+ * Ensure a UI can be release from the owning instance.<p>
+ * For instance, the Processor instance can release the ProcessorInternalDialog instance. The interface
+ * is mainly used to ensure an outdated dialog is release so that a new one will be produced.
+ * @author Mathieu Fortin - February 2024
+ */
+public interface ResourceReleasable {
+	
+	/**
+	 * Release the UI associated to a particular instance so that a new one will be produced.
+	 */
+	public void releaseResources();
+
+}

--- a/src/repicea/simulation/processsystem/SystemManagerDialog.java
+++ b/src/repicea/simulation/processsystem/SystemManagerDialog.java
@@ -27,6 +27,7 @@ import java.awt.event.ActionListener;
 
 import javax.swing.AbstractButton;
 import javax.swing.ButtonGroup;
+import javax.swing.CellEditor;
 import javax.swing.JLabel;
 import javax.swing.JMenu;
 import javax.swing.JMenuBar;
@@ -367,6 +368,12 @@ public class SystemManagerDialog extends REpiceaFrame implements ActionListener,
 			}
 		} else if (evt.getSource().equals(fluxView)) {
 			if (fluxView.isSelected()) {
+				if (processorTable != null) {
+					CellEditor cellEditor = processorTable.getCellEditor();
+					if (cellEditor != null) {
+						cellEditor.stopCellEditing();
+					}
+				}
 				setFluxViewPanel();
 			}
 		}

--- a/src/repicea/simulation/processsystem/SystemPanel.java
+++ b/src/repicea/simulation/processsystem/SystemPanel.java
@@ -145,13 +145,13 @@ public class SystemPanel extends DnDPanel<Processor> implements MouseListener,
 	protected void addManagerComponents() {
 		for (REpiceaUIObject obj : getListManager().getList()) {
 			Processor process = (Processor) obj;
+			process.releaseResources();
 			addProcessorButton(process.getUI(this));
 			for (Processor subProcess : process.getSubProcessors()) {
 				addLinkLine(new ProcessorLinkLine(this, process, subProcess));
 			}
 		}
 	}
-
 	
 	protected boolean addProcessorButton(ProcessorButton processorButton) {
 		boolean bool = false;


### PR DESCRIPTION
Emissions and functional unit left as is because the EndUseWoodProductCarbonUnitFeature requires the functional unit.
