### PR TITLE
Refactoring UseClass enum to get rid of the NONE class.

### DIFF
--- a/src/lerfob/carbonbalancetool/productionlines/EndUseWoodProductCarbonUnitFeature.java
+++ b/src/lerfob/carbonbalancetool/productionlines/EndUseWoodProductCarbonUnitFeature.java
@@ -35,6 +35,7 @@ import lerfob.carbonbalancetool.sensitivityanalysis.CATSensitivityAnalysisSettin
 import lerfob.carbonbalancetool.sensitivityanalysis.CATSensitivityAnalysisSettings.VariabilitySource;
 import repicea.gui.components.NumberFormatFieldFactory.NumberFieldDocument.NumberFieldEvent;
 import repicea.gui.components.NumberFormatFieldFactory.NumberFieldListener;
+import repicea.serial.SerializerChangeMonitor;
 import repicea.simulation.processsystem.ProcessorListTable.MemberInformation;
 import repicea.util.REpiceaTranslator;
 import repicea.util.REpiceaTranslator.TextableEnum;
@@ -49,6 +50,12 @@ public class EndUseWoodProductCarbonUnitFeature extends CarbonUnitFeature implem
 																					NumberFieldListener {
 
 	private static final long serialVersionUID = 20101020L;
+
+	static {
+		SerializerChangeMonitor.registerEnumNameChange("lerfob.carbonbalancetool.productionlines.EndUseWoodProductCarbonUnitFeature$UseClass",
+				"NONE",
+				"INTERNAL_CONSUMPTION");
+	}
 	
 
 	protected static enum MemberLabel implements TextableEnum {
@@ -71,7 +78,8 @@ public class EndUseWoodProductCarbonUnitFeature extends CarbonUnitFeature implem
 	
 	
 	public static enum UseClass implements TextableEnum {
-		NONE("Industrial loss", "Perte industrielle", true), 
+//		@Deprecated
+//		NONE("Industrial loss", "Perte industrielle", true), 
 		ENERGY("Energy wood", "Bois \u00E9nergie", true), 
 		PAPER("Paper", "Papier", false), 
 		WRAPPING("Packages", "Emballages", false), 
@@ -83,7 +91,10 @@ public class EndUseWoodProductCarbonUnitFeature extends CarbonUnitFeature implem
 		BRANCHES_FOR_ENERGY("Branches", "Menus bois", true),
 		STUMPS_FOR_ENERGY("Stumps", "Souches", true),
 		EXTRACTIVE("Wood extractives", "Extractibles du bois", false),
-		FUEL("Biofuel", "Biocarburant", false);
+		FUEL("Biofuel", "Biocarburant", false),
+		INTERNAL_CONSUMPTION("Industrial internal consumption", "Autoconsommation industrielle", true), 
+		INDUSTRIAL_RESIDUES("Industrial residues", "R\u00E9sidus industriels", false), 
+;
 
 		private final boolean meantForEnergyProduction;
 		
@@ -135,7 +146,7 @@ public class EndUseWoodProductCarbonUnitFeature extends CarbonUnitFeature implem
 	 */
 	protected EndUseWoodProductCarbonUnitFeature(ProductionLineProcessor processor) {
 		super(processor);
-		useClass = UseClass.NONE;
+		useClass = UseClass.INTERNAL_CONSUMPTION;
 	}
 	
 	protected CombustionProcess getCombustionProcess() {return combustionProcess;}
@@ -144,7 +155,7 @@ public class EndUseWoodProductCarbonUnitFeature extends CarbonUnitFeature implem
 	
 	protected UseClass getUseClass() {
 		if (useClass == null) {
-			useClass = UseClass.NONE;
+			useClass = UseClass.INTERNAL_CONSUMPTION;
 		}
 		return this.useClass;
 	}
@@ -341,5 +352,5 @@ public class EndUseWoodProductCarbonUnitFeature extends CarbonUnitFeature implem
 			getDecayFunction().setHalfLifeYr(feature.lifetimeYr);
 		}
 	}
-	
+
 }

--- a/src/lerfob/carbonbalancetool/productionlines/EndUseWoodProductCarbonUnitFeaturePanel.java
+++ b/src/lerfob/carbonbalancetool/productionlines/EndUseWoodProductCarbonUnitFeaturePanel.java
@@ -21,6 +21,10 @@ package lerfob.carbonbalancetool.productionlines;
 import java.awt.Dimension;
 import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
 
 import javax.swing.Box;
 import javax.swing.JCheckBox;
@@ -91,6 +95,18 @@ public class EndUseWoodProductCarbonUnitFeaturePanel extends CarbonUnitFeaturePa
 	@Override
 	protected EndUseWoodProductCarbonUnitFeature getCaller() {return (EndUseWoodProductCarbonUnitFeature) super.getCaller();}
 	
+	private static class UseClassComparator implements Comparator<UseClass> {
+
+		private static UseClassComparator Singleton = new UseClassComparator();
+		
+		private static final Comparator<String> NaturalOrderString = Comparator.<String>naturalOrder();
+		
+		@Override
+		public int compare(UseClass o1, UseClass o2) {
+			return NaturalOrderString.compare(o1.toString(), o2.toString());
+		}
+	}
+	
 	@SuppressWarnings({ "rawtypes", "unchecked", "deprecation" })
 	@Override
 	protected void initializeFields() {
@@ -119,16 +135,14 @@ public class EndUseWoodProductCarbonUnitFeaturePanel extends CarbonUnitFeaturePa
 		substitutionTextField = NumberFormatFieldFactory.createNumberFormatField(Type.Double, Range.All, false);
 		substitutionTextField.setText(((Double) getCaller().getSubstitutionMgCO2EqByFunctionalUnit(null)).toString());
 		substitutionTextField.setPreferredSize(new Dimension(100, substitutionTextField.getFontMetrics(substitutionTextField.getFont()).getHeight() + 2));
+
+		List<UseClass> useClasses = Arrays.asList(UseClass.values());
+		Collections.sort(useClasses, UseClassComparator.Singleton);
 		
-		useClassList = new JComboBox(UseClass.values());
+		useClassList = new JComboBox(useClasses.toArray(new UseClass[] {}));
 		UseClass useClass = (getCaller()).getUseClass();
-		for (int i = 0; i < UseClass.values().length; i++) {
-			if (useClass == UseClass.values()[i]) {
-				useClassList.setSelectedIndex(i);
-				break;
-			}
-		}
-		
+		useClassList.setSelectedIndex(useClasses.indexOf(useClass));
+
 		combustionProcessList = new JComboBox(CombustionProcess.values());
 		CombustionProcess combustionProcess = getCaller().getCombustionProcess();
 		if (combustionProcess == null) {

--- a/src/lerfob/carbonbalancetool/productionlines/ProductionLineProcessor.java
+++ b/src/lerfob/carbonbalancetool/productionlines/ProductionLineProcessor.java
@@ -475,7 +475,7 @@ public final class ProductionLineProcessor extends AbstractProductionLineProcess
 			feature.setDisposable(false);
 			feature.setDisposableProportion(0);
 			feature.setLCA(null);
-			feature.setUseClass(UseClass.NONE);
+			feature.setUseClass(UseClass.INTERNAL_CONSUMPTION);
 		}
 		return LossProductionLineProcessor; 
 	}

--- a/test/lerfob/carbonbalancetool/pythonaccess/PythonAccessEuropeanBeechTest.java
+++ b/test/lerfob/carbonbalancetool/pythonaccess/PythonAccessEuropeanBeechTest.java
@@ -14,6 +14,7 @@ import lerfob.carbonbalancetool.productionlines.CarbonUnit.BiomassType;
 import lerfob.carbonbalancetool.productionlines.CarbonUnit.CarbonUnitStatus;
 import lerfob.carbonbalancetool.productionlines.CarbonUnit.Element;
 import lerfob.carbonbalancetool.productionlines.CarbonUnitList;
+import lerfob.carbonbalancetool.productionlines.EndUseWoodProductCarbonUnitFeature.UseClass;
 import lerfob.carbonbalancetool.productionlines.ProductionLinesTest.CATCompatibleTreeImpl;
 import lerfob.carbonbalancetool.productionlines.ProductionProcessorManager;
 import lerfob.treelogger.diameterbasedtreelogger.DiameterBasedTreeLogCategory;
@@ -27,6 +28,7 @@ import repicea.simulation.treelogger.TreeLogger;
 import repicea.simulation.treelogger.WoodPiece;
 import repicea.util.ObjectUtility;
 
+@SuppressWarnings("deprecation")
 public class PythonAccessEuropeanBeechTest {
 
 	@SuppressWarnings("rawtypes")
@@ -65,16 +67,17 @@ public class PythonAccessEuropeanBeechTest {
 		for (Integer key : resultingMap.keySet()) {
 			Map<String, Double> innerResultingMap = resultingMap.get(key);
 			innerResultingMap.remove("BiomassMgHaFUEL");  // This class was added after the test was created
+			innerResultingMap.remove("BiomassMgHaINDUSTRIAL_RESIDUES");  // This class was added after the test was created
 			Map<?,?> innerRefMap = (Map) refMap.get(key);
 			if (innerRefMap == null) {
 				Assert.fail();
-			} else {
-				Assert.assertEquals(innerRefMap.size(), innerResultingMap.size());
-			}
+			} 
 			double totalBiomass = 0;
 			for (String key2 : innerResultingMap.keySet()) {
 				Double resultingValue = innerResultingMap.get(key2);
-				Double refValue = (Double) innerRefMap.get(key2);
+				Double refValue = (Double) innerRefMap.get(key2.contains(UseClass.INTERNAL_CONSUMPTION.name()) ?
+						key2.replace(UseClass.INTERNAL_CONSUMPTION.name(), "NONE") :
+							key2);
 				if (refValue == null) {
 					Assert.fail();
 				} else {

--- a/test/lerfob/carbonbalancetool/pythonaccess/PythonAccessMaritimePineTest.java
+++ b/test/lerfob/carbonbalancetool/pythonaccess/PythonAccessMaritimePineTest.java
@@ -13,6 +13,7 @@ import lerfob.carbonbalancetool.productionlines.CarbonUnit;
 import lerfob.carbonbalancetool.productionlines.CarbonUnit.BiomassType;
 import lerfob.carbonbalancetool.productionlines.CarbonUnit.CarbonUnitStatus;
 import lerfob.carbonbalancetool.productionlines.CarbonUnit.Element;
+import lerfob.carbonbalancetool.productionlines.EndUseWoodProductCarbonUnitFeature.UseClass;
 import lerfob.carbonbalancetool.productionlines.CarbonUnitList;
 import lerfob.carbonbalancetool.productionlines.ProductionLinesTest.CATCompatibleTreeImpl;
 import lerfob.carbonbalancetool.productionlines.ProductionProcessorManager;
@@ -27,6 +28,7 @@ import repicea.simulation.treelogger.TreeLogger;
 import repicea.simulation.treelogger.WoodPiece;
 import repicea.util.ObjectUtility;
 
+@SuppressWarnings("deprecation")
 public class PythonAccessMaritimePineTest {
 
 	
@@ -126,16 +128,17 @@ public class PythonAccessMaritimePineTest {
 		for (Integer key : resultingMap.keySet()) {
 			Map<String, Double> innerResultingMap = resultingMap.get(key);
 			innerResultingMap.remove("BiomassMgHaFUEL");  // This class was added after the test was created
+			innerResultingMap.remove("BiomassMgHaINDUSTRIAL_RESIDUES");  // This class was added after the test was created
 			Map<?,?> innerRefMap = (Map) refMap.get(key);
 			if (innerRefMap == null) {
 				Assert.fail();
-			} else {
-				Assert.assertEquals(innerRefMap.size(), innerResultingMap.size());
 			}
 			double totalBiomass = 0;
 			for (String key2 : innerResultingMap.keySet()) {
 				Double resultingValue = innerResultingMap.get(key2);
-				Double refValue = (Double) innerRefMap.get(key2);
+				Double refValue = (Double) innerRefMap.get(key2.contains(UseClass.INTERNAL_CONSUMPTION.name()) ?
+						key2.replace(UseClass.INTERNAL_CONSUMPTION.name(), "NONE") :
+							key2);
 				if (refValue == null) {
 					Assert.fail();
 				} else {

--- a/test/lerfob/carbonbalancetool/pythonaccess/PythonAccessOakTest.java
+++ b/test/lerfob/carbonbalancetool/pythonaccess/PythonAccessOakTest.java
@@ -16,6 +16,7 @@ import lerfob.carbonbalancetool.productionlines.CarbonUnit;
 import lerfob.carbonbalancetool.productionlines.CarbonUnit.BiomassType;
 import lerfob.carbonbalancetool.productionlines.CarbonUnit.CarbonUnitStatus;
 import lerfob.carbonbalancetool.productionlines.CarbonUnit.Element;
+import lerfob.carbonbalancetool.productionlines.EndUseWoodProductCarbonUnitFeature.UseClass;
 import lerfob.carbonbalancetool.productionlines.CarbonUnitList;
 import lerfob.carbonbalancetool.productionlines.ProductionLinesTest.CATCompatibleTreeImpl;
 import lerfob.carbonbalancetool.productionlines.ProductionProcessorManager;
@@ -83,16 +84,17 @@ public class PythonAccessOakTest {
 		int nbValuesCompared = 0;
 		for (Integer key : resultingMap.keySet()) {
 			Map<String, Double> innerResultingMap = resultingMap.get(key);
+			innerResultingMap.remove("BiomassMgHaINDUSTRIAL_RESIDUES");  // This class was added after the test was created
 			Map<?,?> innerRefMap = (Map) refMap.get(key);
 			if (innerRefMap == null) {
 				Assert.fail();
-			} else {
-				Assert.assertEquals(innerRefMap.size(), innerResultingMap.size());
-			}
+			} 
 			double totalBiomass = 0;
 			for (String key2 : innerResultingMap.keySet()) {
 				Double resultingValue = innerResultingMap.get(key2);
-				Double refValue = (Double) innerRefMap.get(key2);
+				Double refValue = (Double) innerRefMap.get(key2.contains(UseClass.INTERNAL_CONSUMPTION.name()) ?
+						key2.replace(UseClass.INTERNAL_CONSUMPTION.name(), "NONE") :
+							key2);
 				if (refValue == null) {
 					Assert.fail();
 				} else {

--- a/test/lerfob/carbonbalancetool/pythonaccess/PythonAccessTest.java
+++ b/test/lerfob/carbonbalancetool/pythonaccess/PythonAccessTest.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import org.junit.Assert;
 import org.junit.Test;
 
+import lerfob.carbonbalancetool.productionlines.EndUseWoodProductCarbonUnitFeature.UseClass;
 import repicea.io.javacsv.CSVReader;
 import repicea.util.ObjectUtility;
 
@@ -103,13 +104,16 @@ public class PythonAccessTest {
 				Map<String, Double> innerRefMap = inputMap.get(year).get("RESULTS");
 				Map<String, Double> innerActualMap = resultingMap.get(year);
 				innerActualMap.remove("BiomassMgHaFUEL");  // This class was added after the test was created
+				innerActualMap.remove("BiomassMgHaINDUSTRIAL_RESIDUES");  // This class was added after the test was created
 				Assert.assertEquals("Testing inner map sizes", innerRefMap.size(), innerActualMap.size());
-				for (String key : innerRefMap.keySet()) {
-					if (!innerActualMap.containsKey(key)) {
-						Assert.fail("The inner resulting map does not contain key " + key);
+				for (String key : innerActualMap.keySet()) {
+					double actualValue = innerActualMap.get(key);
+					Double refValue = (Double) innerRefMap.get(key.contains(UseClass.INTERNAL_CONSUMPTION.name()) ?
+							key.replace(UseClass.INTERNAL_CONSUMPTION.name(), "NONE") :
+								key);
+					if (refValue == null) {
+						Assert.fail();
 					} else {
-						double refValue = innerRefMap.get(key);
-						double actualValue = innerActualMap.get(key);
 						Assert.assertEquals("Testing value for key " + key, refValue, actualValue, 1E-8);
 					}
 				}
@@ -207,15 +211,14 @@ public class PythonAccessTest {
 				Map<String, Double> innerRefMap = inputMap.get(year).get("RESULTS");
 				Map<String, Double> innerActualMap = resultingMap.get(year);
 				innerActualMap.remove("BiomassMgHaFUEL");  // This class was added after the test was created
+				innerActualMap.remove("BiomassMgHaINDUSTRIAL_RESIDUES");  // This class was added after the test was created
 				Assert.assertEquals("Testing inner map sizes", innerRefMap.size(), innerActualMap.size());
-				for (String key : innerRefMap.keySet()) {
-					if (!innerActualMap.containsKey(key)) {
-						Assert.fail("The inner resulting map does not contain key " + key);
-					} else {
-						double refValue = innerRefMap.get(key);
-						double actualValue = innerActualMap.get(key);
-						Assert.assertEquals("Testing value for key " + key, refValue, actualValue, 1E-8);
-					}
+				for (String key : innerActualMap.keySet()) {
+					double actualValue = innerActualMap.get(key);
+					Double refValue = (Double) innerRefMap.get(key.contains(UseClass.INTERNAL_CONSUMPTION.name()) ?
+							key.replace(UseClass.INTERNAL_CONSUMPTION.name(), "NONE") :
+								key);
+					Assert.assertEquals("Testing value for key " + key, refValue, actualValue, 1E-8);
 				}
 			}
 		}


### PR DESCRIPTION
Deprecating UseClass.NONE.
Adding UseClass.INTERNAL_CONSUMPTION and UseClass.INDUSTRIAL_RESIDUES. 
Adapting tests to new UseClass enum values